### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/ruralant/portfolio/security/code-scanning/1](https://github.com/ruralant/portfolio/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required. Since this workflow primarily involves running tests and uploading artifacts, it only needs `contents: read` permissions. This change ensures that the `GITHUB_TOKEN` cannot perform unintended write operations.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
